### PR TITLE
editable prompt

### DIFF
--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -59,6 +59,8 @@ src/
         route.ts
       review/
         route.ts
+    documentation/
+      page.tsx
     note/
       [id]/
         page.tsx
@@ -237,26 +239,6 @@ export function SOAPNote({ content, className }: SOAPNoteProps) {
 }
 </file>
 
-<file path="src/components/ui/textarea.tsx">
-import { forwardRef, TextareaHTMLAttributes } from "react";
-import { cn } from "@/lib/utils";
-
-export const Textarea = forwardRef<
-  HTMLTextAreaElement,
-  TextareaHTMLAttributes<HTMLTextAreaElement>
->(({ className, ...props }, ref) => (
-  <textarea
-    ref={ref}
-    className={cn(
-      "w-full rounded-md border border-gray-300 bg-transparent p-3 text-sm shadow-sm focus-visible:ring-2 focus-visible:ring-gray-400",
-      className
-    )}
-    {...props}
-  />
-));
-Textarea.displayName = "Textarea";
-</file>
-
 <file path="src/lib/clipText.ts">
 /** Clip a string to ~8k GPT tokens (~32k chars), keeping start & end. */
 export function clipText(s: string, maxChars = 32000) {
@@ -306,50 +288,6 @@ export interface Review {
 }
 </file>
 
-<file path=".gitignore">
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
-# dependencies
-/node_modules
-/.pnp
-.pnp.*
-.yarn/*
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/versions
-
-# testing
-/coverage
-
-# next.js
-/.next/
-/out/
-
-# production
-/build
-
-# misc
-.DS_Store
-*.pem
-
-# debug
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-.pnpm-debug.log*
-
-# env files (can opt-in for committing if needed)
-.env*
-
-# vercel
-.vercel
-
-# typescript
-*.tsbuildinfo
-next-env.d.ts
-</file>
-
 <file path=".npmrc">
 legacy-peer-deps=true
 </file>
@@ -391,45 +329,6 @@ const config = {
 export default config;
 </file>
 
-<file path="README.md">
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
-
-## Getting Started
-
-First, run the development server:
-
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-</file>
-
 <file path="tsconfig.json">
 {
   "compilerOptions": {
@@ -460,37 +359,6 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 }
 </file>
 
-<file path="src/components/ui/button.tsx">
-import { forwardRef, ButtonHTMLAttributes } from "react";
-import { cn } from "@/lib/utils";
-
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "default" | "secondary";
-  loading?: boolean;
-}
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "default", loading, children, ...props }, ref) => (
-    <button
-      ref={ref}
-      className={cn(
-        "inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-bold uppercase transition-colors disabled:opacity-50",
-        variant === "default" &&
-          "bg-yellow-400 text-black hover:bg-yellow-500 focus-visible:ring-yellow-300",
-        variant === "secondary" &&
-          "bg-gray-100 hover:bg-gray-200 focus-visible:ring-gray-300",
-        className
-      )}
-      disabled={loading || props.disabled}
-      {...props}
-    >
-      {loading && <span className="animate-spin h-4 w-4 border-2 border-current border-t-transparent rounded-full" />}
-      {children}
-    </button>
-  )
-);
-Button.displayName = "Button";
-</file>
-
 <file path="src/components/ui/card.tsx">
 import { cn } from "@/lib/utils";
 
@@ -512,6 +380,26 @@ export function Card({
     </div>
   );
 }
+</file>
+
+<file path="src/components/ui/textarea.tsx">
+import { forwardRef, TextareaHTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export const Textarea = forwardRef<
+  HTMLTextAreaElement,
+  TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(
+      "w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 p-3 text-sm shadow-sm placeholder:text-gray-500 dark:placeholder:text-gray-400 focus-visible:ring-2 focus-visible:ring-gray-400 dark:focus-visible:ring-gray-500 focus-visible:outline-none",
+      className
+    )}
+    {...props}
+  />
+));
+Textarea.displayName = "Textarea";
 </file>
 
 <file path="src/lib/parseCsv.ts">
@@ -617,69 +505,415 @@ export function cn(...inputs: ClassValue[]) {
 }
 </file>
 
-<file path="src/app/globals.css">
-@import "tailwindcss";
+<file path=".gitignore">
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-manrope);
-}
+# testing
+/coverage
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+repomix-output.xml
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+</file>
+
+<file path="src/app/documentation/page.tsx">
+import Link from "next/link";
+import { Card } from "@/components/ui/card";
+import { Home, FileText } from "lucide-react";
+
+export default function Documentation() {
+  return (
+    <>
+      <nav className="bg-black/90 backdrop-blur-sm sticky top-0 z-[100]">
+        <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <Link href="/" className="text-xl font-black text-white tracking-tight hover:text-gray-200 transition-colors flex items-center">
+                <span className="mr-2">🧼</span>
+                Project SOAP
+              </Link>
+            </div>
+            <div className="flex items-center space-x-6">
+              <Link href="/" className="text-white hover:text-gray-200 transition-colors flex items-center">
+                <Home size={20} />
+              </Link>
+              <Link href="/documentation" className="text-white hover:text-gray-200 transition-colors font-medium flex items-center">
+                <FileText size={20} />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </nav>
+      
+      <main className="container mx-auto max-w-6xl space-y-8 py-12 px-4 sm:px-6 lg:px-8">
+        <Card>
+          <div className="max-w-none">
+            <h2 className="text-3xl font-bold mb-8 text-gray-900 dark:text-gray-100">How It Works</h2>
+            
+                         <div className="space-y-10">
+               <div>
+                 <h3 className="text-2xl font-semibold mb-6 text-gray-800 dark:text-gray-200 flex items-center">
+                   <span className="bg-gray-600 dark:bg-gray-500 text-white rounded-full w-8 h-8 flex items-center justify-center text-lg font-bold mr-3">1</span>
+                   Generate SOAP Note
+                 </h3>
+                 <div className="ml-11 space-y-4">
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300"><strong>Input</strong>: Paste a full patient encounter transcript formatted as user, assistant. Be sure to include all relevant modules.</p>
+                     </div>
+                   </div>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">The app parses the dialogue into clinician/patient turns using <code className="text-sm bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 px-2 py-1 rounded font-mono">src/lib/parseCsv.ts</code>.</p>
+                     </div>
+                   </div>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">A <strong>system prompt</strong> (<code className="text-sm bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 px-2 py-1 rounded font-mono">src/lib/prompts.ts</code>) instructs the AI to produce a concise, markdown-formatted SOAP note.</p>
+                     </div>
+                   </div>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">The transcript + prompt are sent to the <strong><code className="text-sm bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 px-2 py-1 rounded font-mono">/api/generate</code></strong> endpoint, which calls the OpenAI API.</p>
+                     </div>
+                   </div>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">The AI-generated SOAP note is stored in memory (<code className="text-sm bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 px-2 py-1 rounded font-mono">src/lib/store.ts</code>) and displayed to the user.</p>
+                     </div>
+                   </div>
+                 </div>
+                 
+                 {/* Expandable code block for prompts.ts */}
+                 <div className="ml-11 mt-6">
+                   <details className="group">
+                     <summary className="cursor-pointer text-base font-semibold text-gray-800 dark:text-gray-200 hover:text-gray-900 dark:hover:text-gray-100 transition-colors flex items-center bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-700">
+                       <span className="mr-3 text-lg">▶</span>
+                       <span className="group-open:hidden">Show SOAP generation prompt</span>
+                       <span className="hidden group-open:inline">Hide SOAP generation prompt</span>
+                     </summary>
+                     <div className="mt-3 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+                       <div className="bg-gray-50 dark:bg-gray-800 px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+                         <p className="text-xs font-mono text-gray-600 dark:text-gray-400">src/lib/prompts.ts</p>
+                       </div>
+                       <div className="max-h-80 overflow-y-auto">
+                         <pre className="text-xs font-mono text-gray-800 dark:text-gray-200 bg-white dark:bg-gray-900 p-4 whitespace-pre-wrap">{`export const systemSOAP = \`
+You are a meticulous medical scribe. From the **patient's statements _and_ all actions ALREADY performed in this encounter** (ignore clinician questions), craft a concise **markdown** SOAP note.
+
+## S – Subjective
+
+**HPI (paragraph)** – Chief complaint, onset/chronology, quality, radiation, aggravating & relieving factors, pertinent positives **and** negatives, medication & risk-factor context.  
+**ROS (≤ 6 bullets)** – Focused positives/negatives not already in HPI.
+
+## O – Objective (≤ 6 bullets total)
+
+• **Vitals**: write all provided vitals or "—"  
+• **Physical Exam**: focused findings or "—"  
+• **Diagnostics**: include **every** EKG/lab/imaging result mentioned; collapse duplicates (e.g., "ECG: ST-elevation V2–V4, T-wave inversion III"). Use "—" if none.
+
+## A – Assessment
+
+1–2 sentences: patient profile, pivotal findings, **ranked** leading differential (e.g., "ACS > unstable angina > pericarditis").
+
+## P – Plan
+
+### Completed (what _has already been done_)  
+• List interventions that the transcript shows were **ordered _and_ acknowledged as carried out** (keywords: *administered, started, given, established, attached, initiated*).  
+*Do **not** list these again in "Next".*
+
+### Next (what is still pending)  
+• Diagnostics, therapeutics, disposition **not yet performed** (≤ 6 bullets combined with "Completed").  
+Use "—" if nothing remains.
+
+---
+
+### Formatting rules
+• Third-person throughout ("Mr. Jones states …").  
+• ≤ 6 bullets in ROS, Objective, and **combined** Plan sections.  
+• Use "—" when information is absent; never invent data.  
+• Resolve conflicting patient statements by preferring the **most specific or recent** information.  
+• Preserve clinically important wording (e.g., "heart attack," not "heart failure," if that's what was said).  
+• Keep the entire note ≤ 250 words.
+\`;`}</pre>
+                       </div>
+                     </div>
+                   </details>
+                 </div>
+               </div>
+
+               <div>
+                 <h3 className="text-2xl font-semibold mb-6 text-gray-800 dark:text-gray-200 flex items-center">
+                   <span className="bg-gray-600 dark:bg-gray-500 text-white rounded-full w-8 h-8 flex items-center justify-center text-lg font-bold mr-3">2</span>
+                   Edit & Submit
+                 </h3>
+                 <div className="ml-11 space-y-4">
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">Users can click <strong>&quot;Edit &amp; Review&quot;</strong> to refine the SOAP note.</p>
+                     </div>
+                   </div>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">Their edits are saved as the <strong>student note</strong> for the encounter.</p>
+                     </div>
+                   </div>
+                 </div>
+               </div>
+
+               <div>
+                 <h3 className="text-2xl font-semibold mb-6 text-gray-800 dark:text-gray-200 flex items-center">
+                   <span className="bg-gray-600 dark:bg-gray-500 text-white rounded-full w-8 h-8 flex items-center justify-center text-lg font-bold mr-3">3</span>
+                   AI Review & Grading
+                 </h3>
+                 <div className="ml-11 space-y-4">
+                   <p className="text-gray-700 dark:text-gray-300 mb-4">On submission, the <strong><code className="text-sm bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 px-2 py-1 rounded font-mono">/api/review</code></strong> endpoint:</p>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">Retrieves the original AI note and the student-edited note.</p>
+                     </div>
+                   </div>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">Uses a <strong>PDQI-9 scoring rubric</strong> with clinical appropriateness rules (<code className="text-sm bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 px-2 py-1 rounded font-mono">src/app/api/review/route.ts</code>).</p>
+                     </div>
+                   </div>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">Compares both notes against the encounter transcript.</p>
+                     </div>
+                   </div>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300 mb-2">Returns JSON with:</p>
+                       <div className="ml-6 space-y-2">
+                         <div className="flex items-start space-x-3">
+                           <div className="w-1.5 h-1.5 bg-gray-400 dark:bg-gray-500 rounded-full mt-2.5 flex-shrink-0"></div>
+                           <p className="text-gray-600 dark:text-gray-400"><strong>Scores</strong> for each PDQI-9 dimension</p>
+                         </div>
+                         <div className="flex items-start space-x-3">
+                           <div className="w-1.5 h-1.5 bg-gray-400 dark:bg-gray-500 rounded-full mt-2.5 flex-shrink-0"></div>
+                           <p className="text-gray-600 dark:text-gray-400"><strong>Delta scores</strong> (student vs. AI)</p>
+                         </div>
+                         <div className="flex items-start space-x-3">
+                           <div className="w-1.5 h-1.5 bg-gray-400 dark:bg-gray-500 rounded-full mt-2.5 flex-shrink-0"></div>
+                           <p className="text-gray-600 dark:text-gray-400"><strong>Per-dimension change comments</strong></p>
+                         </div>
+                         <div className="flex items-start space-x-3">
+                           <div className="w-1.5 h-1.5 bg-gray-400 dark:bg-gray-500 rounded-full mt-2.5 flex-shrink-0"></div>
+                           <p className="text-gray-600 dark:text-gray-400"><strong>Overall feedback</strong></p>
+                         </div>
+                       </div>
+                     </div>
+                   </div>
+                 </div>
+                 
+                 {/* Expandable code block for review route */}
+                 <div className="ml-11 mt-6">
+                   <details className="group">
+                     <summary className="cursor-pointer text-base font-semibold text-gray-800 dark:text-gray-200 hover:text-gray-900 dark:hover:text-gray-100 transition-colors flex items-center bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-700">
+                       <span className="mr-3 text-lg">▶</span>
+                       <span className="group-open:hidden">Show AI review & grading code</span>
+                       <span className="hidden group-open:inline">Hide AI review & grading code</span>
+                     </summary>
+                     <div className="mt-3 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+                       <div className="bg-gray-50 dark:bg-gray-800 px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+                         <p className="text-xs font-mono text-gray-600 dark:text-gray-400">src/app/api/review/route.ts</p>
+                       </div>
+                       <div className="max-h-80 overflow-y-auto">
+                         <pre className="text-xs font-mono text-gray-800 dark:text-gray-200 bg-white dark:bg-gray-900 p-4 whitespace-pre-wrap">{`import { NextResponse } from "next/server";
+import { openai } from "@/lib/openai";
+import { db } from "@/lib/store";
+import { clipText } from "@/lib/clipText";
+
+const reviewPrompt = \`
+
+You are an attending physician using the **PDQI-9** rubric with emphasis on **clinical appropriateness**.
+
+Notes:
+• NOTE_A = baseline AI-generated SOAP (reference)  
+• NOTE_B = student-edited version
+
+**CRITICAL: Use the CONTEXT transcript to judge clinical appropriateness. Inappropriate treatments/medications for the actual clinical scenario should receive LOW scores (1-2).**
+
+Step 1 – Score BOTH notes (Likert 1-5 scale)
+  • **Scoring Guidelines:**
+    - **5**: Excellent, clinically appropriate, evidence-based
+    - **4**: Good, mostly appropriate with minor issues
+    - **3**: Adequate, some concerns but not harmful
+    - **2**: Poor, inappropriate for clinical scenario or potentially harmful
+    - **1**: Dangerous, contraindicated, or completely inappropriate
+
+  • **Key Dimensions with Clinical Focus:**
+    - **accurate**: Factually correct AND clinically appropriate for the case
+    - **useful**: Helpful for patient care AND safe/appropriate treatments
+    - **thorough**: Complete relevant info WITHOUT inappropriate additions
+    - **up_to_date**: Current guidelines AND appropriate for this patient
+    - **organized/comprehensible/succinct/synthesized/consistent**: Standard PDQI-9
+
+  • **PENALIZE HEAVILY**: 
+    - Wrong medications for the condition (e.g., antibiotics for MI)
+    - Inappropriate treatments that don't match the clinical scenario
+    - Dangerous or contraindicated interventions
+
+Step 2 – Delta  
+  • delta = score_B − score_A (range −4→+4).  
+  • overall_delta = sum of deltas (range −36→+36).
+
+Step 3 – Edit analysis  
+  • **REQUIRED**: Create a "changes" entry for EVERY dimension with a non-zero delta.  
+  • If delta ≠ 0, you MUST explain why that dimension score changed.  
+  • For each non-zero delta:  
+      – \\\`dimension\\\` name (exact PDQI-9 dimension that changed)  
+      – \\\`impact\\\` improved | worsened | neutral  
+      – \\\`snippet\\\` ≤20 words (specific text that caused the change)  
+      – \\\`comment\\\` coaching ≤25 words explaining WHY the score changed
+
+Return STRICT JSON only:
+
+{
+  "baseline_scores":    { "up_to_date":int, "accurate":int, "thorough":int, "useful":int, "organized":int, "comprehensible":int, "succinct":int, "synthesized":int, "consistent":int },
+  "student_scores":     { "up_to_date":int, "accurate":int, "thorough":int, "useful":int, "organized":int, "comprehensible":int, "succinct":int, "synthesized":int, "consistent":int },
+  "delta_scores":       { "up_to_date":int, "accurate":int, "thorough":int, "useful":int, "organized":int, "comprehensible":int, "succinct":int, "synthesized":int, "consistent":int },
+  "overall_delta": int,
+  "changes": [
+     { "dimension":str, "impact":str, "snippet":str, "comment":str }
+  ],
+
+  "global_comment": str
+}\\\`;
+
+export async function POST(req: Request) {
+  const { id, studentNote } = await req.json();
+  const enc = db.get(id);
+  if (!enc?.aiNote) {
+    return NextResponse.json({ error: "Encounter not found" }, { status: 404 });
   }
-}
+  enc.studentNote = studentNote;
 
-body {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: var(--foreground);
-  font-family: var(--font-manrope), system-ui, sans-serif;
-  min-height: 100vh;
-}
+  const transcript = clipText(enc.csv);
+  console.log("Transcript chars:", transcript.length);
 
-/* Enhanced SOAP Note Formatting */
-.soap-note {
-  line-height: 1.7;
-  font-feature-settings: "kern" 1, "liga" 1;
-}
+  const messages = [
+    {
+      role: "system" as const,
+      content: reviewPrompt,
+    },
+    {
+      role: "user" as const,
+      name: "CONTEXT",
+      content:
+        "Full encounter transcript (User & Assistant turns):\\n\\"\\"\\"\\n" +
+        transcript +
+        "\\n\\"\\"\\"",
+    },
+    {
+      role: "user" as const,
+      name: "NOTE_A",
+      content: enc.aiNote,
+    },
+    {
+      role: "user" as const,
+      name: "NOTE_B",
+      content: studentNote,
 
-.soap-note h2 {
-  letter-spacing: -0.025em;
-}
+    },
+  ];
 
-.soap-note p {
-  text-align: justify;
-  hyphens: auto;
-}
+  const res = await openai.chat.completions.create({
+    model: "gpt-4o",
+    messages,
+    temperature: 0,
+    response_format: { type: "json_object" },
+  });
 
-.soap-note ul {
-  list-style: none;
-}
+  const rubric = JSON.parse(res.choices[0].message.content ?? "{}");
+  enc.reviewJson = rubric;
+  return NextResponse.json(rubric);
+}`}</pre>
+                       </div>
+                     </div>
+                   </details>
+                 </div>
+               </div>
 
-.soap-note strong {
-  font-weight: 600;
-}
-
-/* Improved readability for medical content */
-.soap-note code {
-  font-variant-numeric: tabular-nums;
-}
-
-/* Better spacing for nested content */
-.soap-note li p {
-  margin-bottom: 0.5rem;
-}
-
-.soap-note li:last-child {
-  margin-bottom: 0;
+               <div>
+                 <h3 className="text-2xl font-semibold mb-6 text-gray-800 dark:text-gray-200 flex items-center">
+                   <span className="bg-gray-600 dark:bg-gray-500 text-white rounded-full w-8 h-8 flex items-center justify-center text-lg font-bold mr-3">4</span>
+                   Feedback Display
+                 </h3>
+                 <div className="ml-11 space-y-4">
+                   <p className="text-gray-700 dark:text-gray-300 mb-4">The UI presents a detailed breakdown:</p>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">Scores and deltas per dimension</p>
+                     </div>
+                   </div>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">Specific snippets causing score changes</p>
+                     </div>
+                   </div>
+                   <div className="flex items-start space-x-3">
+                     <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                     <div>
+                       <p className="text-gray-700 dark:text-gray-300">Global comments for improvement</p>
+                     </div>
+                   </div>
+                 </div>
+               </div>
+             </div>
+          </div>
+        </Card>
+      </main>
+    </>
+  );
 }
 </file>
 
@@ -734,226 +968,197 @@ export default function RootLayout({
 }
 </file>
 
-<file path="src/app/page.tsx">
-"use client";
-import { useState } from "react";
-import { Textarea } from "@/components/ui/textarea";
-import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import { SOAPNote } from "@/components/ui/soap-note";
-import { toast } from "sonner";
-import Link from "next/link";
+<file path="src/components/ui/button.tsx">
+import { forwardRef, ButtonHTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
 
-export default function Home() {
-  const [csv, setCsv] = useState("");
-  const [aiNote, setAiNote] = useState("");
-  const [id, setId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  const exampleContent = `--- Module: History ---
-[10:28:26 PM] User: When did it start?
-[10:28:27 PM] Assistant: Well, it began about a week ago.
-[10:28:42 PM] User: Describe the pain
-[10:28:42 PM] Assistant: It's a heavy, tight pressure right in the center of my chest.
-[10:28:54 PM] User: How long does it last?
-[10:28:55 PM] Assistant: It lasts for around 5 to 10 minutes before it eases up with rest.
-[10:29:54 PM] User: What's your medical history
-[10:29:54 PM] Assistant: Umm, can you be more specific about what you're asking?
-[10:30:42 PM] User: Do you have any ongoing disease?
-[10:30:43 PM] Assistant: I've been managing hypertension and cholesterol with medication.
-[10:31:05 PM] User: Ever had an MI?
-[10:31:06 PM] Assistant: I'm not quite sure what "MI" means. Could you explain that to me?
-[10:31:17 PM] User: Ever had a heart attack?
-[10:31:18 PM] Assistant: No, I've never had a heart attack before.
-[10:31:34 PM] User: Ever had surgery?
-[10:31:34 PM] Assistant: No, I've never had any surgery.
-[10:31:41 PM] User: Allergies?
-[10:31:42 PM] Assistant: No, I don't have any known allergies.
-[10:32:08 PM] User: Which meds are you currently taking?
-[10:32:08 PM] Assistant: I'm taking Hydrochlorothiazide for blood pressure and Atorvastatin for cholesterol.
-[10:32:33 PM] User: What are your vitals?
-[10:32:34 PM] Assistant: I'm not sure exactly. The doctors usually check them during my appointments, but I don't remember the specific numbers.
-[10:33:17 PM] User: Any relevant family history?
-[10:33:18 PM] Assistant: Yeah, my father had a heart attack at the age of 52.
-[10:33:41 PM] User: Do you regularly consult with a cardiologist?
-[10:33:41 PM] Assistant: I try to follow up regularly with my doctor, but it's been about six months since my last check-up.
-[10:34:05 PM] User: Does the pain irradiate?
-[10:34:06 PM] Assistant: Yes, sometimes it spreads and radiates into my left arm.
-[10:34:24 PM] User: What are you doing when the pain appears?
-[10:34:25 PM] Assistant: It usually happens during physical activity, like climbing stairs or hurrying somewhere.
-[10:35:26 PM] User: Have you had any recent lab workup
-[10:35:27 PM] Assistant: No, I haven't had any recent lab work done.
-[10:36:09 PM] User: What does your diet look like
-[10:36:10 PM] Assistant: Well, I try to eat healthy, but there are days when I skip meals or grab something quick and unhealthy because of work.
-[10:36:23 PM] User: What are your habits?
-[10:36:24 PM] Assistant: I jog regularly in the mornings before work, and I'm also a moderate smoker.
---- Module: Differential Diagnosis ---
-[10:37:27 PM] User: Unstable angina
-[10:37:28 PM] Assistant: Why do you think unstable angina is on your differential for Mr. Jones?
-[10:38:33 PM] User: The pain lasts less than 40min, it alleviates with rest, he has a history of high cholesterol
-[10:38:36 PM] Assistant: Yes, unstable angina is a strong consideration here. The chest pain lasting 5 to 10 minutes and resolving with rest is characteristic of angina. His history of high cholesterol and hypertension, along with a family history of heart disease, puts him at increased risk for coronary artery disease. What is the second condition on your differential?
-[10:39:45 PM] User: We should rule out a myocardial infarction
-[10:39:48 PM] Assistant: Consider using broad terms. "Acute Coronary Syndrome", which includes Myocardial Infarction or Unstable Angina, is a good way to phrase this possibility. Since you've already mentioned Unstable Angina, let's focus on another separate condition that could be causing his symptoms. What's another differential diagnosis you are considering?
-[10:42:33 PM] User: Should we be considering a pulmonary embolism?
-[10:42:35 PM] Assistant: Yes, a pulmonary embolism is a valid consideration. Given his recent travel history and periods of immobility, combined with smoking, they are risk factors for venous thromboembolism. Sudden onset chest pain could point towards a pulmonary embolism. What's the third condition on your differential?
-[10:43:11 PM] User: Panic attacks
-[10:43:13 PM] Assistant: While panic attacks can present with chest pain, in this scenario, we should prioritize ruling out potentially life-threatening cardiac or pulmonary conditions first. Could you suggest another condition that could be causing his symptoms?
-[10:43:38 PM] User: Can you guide my thought?
-[10:43:40 PM] Assistant: Certainly. Consider conditions that could involve inflammation around the heart or increases in pressure on the heart. These could be attributed to recent respiratory symptoms or a history of chronic tension and stress, affecting the heart or its surrounding structures. What's another diagnosis you might consider?
-[10:43:56 PM] User: Myocarditis
-[10:43:58 PM] Assistant: Myocarditis is a reasonable consideration given his recent cold, as viral infections can sometimes lead to inflammation of the heart muscle. This could cause chest pain and explain his symptoms. Now that we've discussed three conditions, let's proceed with the case.
---- Module: Results Interpretation ---
-[10:46:44 PM] User: Normal rate - between 100 and 75, maybe high 80s.
-[10:46:45 PM] Assistant: Hmm, I would suggest double-checking that rate. Try to determine it more precisely.
-[10:48:26 PM] User: 75 bpm
-[10:48:27 PM] Assistant: Good, that rate is within normal range. What about the rhythm? Do you notice anything specific?
-[10:48:38 PM] User: Sinus rhythm
-[10:48:39 PM] Assistant: Correct, it is a regular sinus rhythm. Are there any noticeable ST changes on the EKG?
-[10:48:48 PM] User: No ST changes
-[10:48:49 PM] Assistant: Great, that's correct: there are no ST changes. Please continue to the next step to continue with the case.
---- Module: Re-Evaluation ---
-[10:50:14 PM] User: Looks like and anterior STEMI
-[10:50:15 PM] Assistant: Alright, recognizing those changes on the EKG is important. What would you like us to do next for Mr. Jones?
-[10:50:40 PM] User: Prep him for cath lab
-[10:50:41 PM] Assistant: Understood, I'll notify the cath lab and ensure they're ready for Mr. Jones. What else would you like to address while we're preparing him?
-[10:50:58 PM] User: What's his BP?
-[10:50:59 PM] Assistant: Let me check that for you. Mr. Jones's blood pressure is currently 160/95. What would you like to do next?
-[10:51:19 PM] User: Let's give him labetalol to lower it
-[10:51:20 PM] Assistant: We can certainly work on managing his blood pressure. I'll prepare the labetalol for administration. Is there anything else you would like to address for Mr. Jones right now?
-[10:51:46 PM] User: Do we have the troponin value?
-[10:51:47 PM] Assistant: Let's see... Mr. Jones's initial troponin level is elevated, indicating cardiac involvement. What would you like to do with this information?
-[10:52:47 PM] User: Let's hook him to a monitor
-[10:52:49 PM] Assistant: We'll get Mr. Jones on the monitor right away to keep a close eye on his vitals. What would you like to do next?
-[10:53:04 PM] User: What are his vitals now?
-[10:53:05 PM] Assistant: Okay, let me check that for you. Mr. Jones's current vitals are:
-- Blood pressure: 160/95
-- Heart rate: 100 beats per minute
-- Respiratory rate: 20 breaths per minute
-- Oxygen saturation: 96% on room air
-Is there anything specific you'd like to do with this information?
-[10:53:46 PM] User: Let's give his sublingual nitro
-[10:53:48 PM] Assistant: Alright, I'll administer the sublingual nitroglycerin to help with his chest pain. What would you like us to focus on next?
-[10:54:15 PM] User: Let's have a crash cart ready
-[10:54:16 PM] Assistant: We'll make sure the crash cart is at the ready, just in case. What other steps would you like us to take for Mr. Jones?
-[10:55:34 PM] User: Guide my thought
-[10:55:35 PM] Assistant: I understand this can feel like a lot to manage. Your focus on ensuring Mr. Jones's stability is key. Please let me know how you'd like to proceed with his care.
-[10:55:58 PM] User: Should we give him some fluids?
-[10:55:59 PM] Assistant: We can start an IV line for Mr. Jones, which will allow us to give fluids if needed. Would you like us to proceed with establishing IV access and anything else?
-[10:56:18 PM] User: Stablish an IV
-[10:56:19 PM] Assistant: I'll go ahead and establish IV access for Mr. Jones. Is there anything else you'd like to address for his ongoing care?
-[10:56:36 PM] User: Notify family
-[10:56:37 PM] Assistant: I'll arrange for someone to notify Mr. Jones's family about his condition and that he's being prepared for further treatment. Is there anything else you'd like to do right now?
-[10:57:09 PM] User: Take another ekg
-[10:57:11 PM] Assistant: Alright, we'll go ahead and perform another EKG to monitor any changes. Meanwhile, is there anything else you would like to address with Mr. Jones?
-[10:57:45 PM] User: Do an echo
-[10:57:46 PM] Assistant: An echo can provide valuable information about Mr. Jones's heart function. I'll make arrangements for an echocardiogram. In the meantime, is there anything else you'd like to do?
-[10:58:02 PM] User: Any suggestions?
-[10:58:03 PM] Assistant: I'm here to assist with what you decide is best for Mr. Jones. You've made some important decisions so far. Please let me know how you'd like to continue with his care.
-[10:59:04 PM] User: Let's control the rate
-[10:59:05 PM] Assistant: To control Mr. Jones's heart rate, we can consider medications like beta-blockers which you've already mentioned, we'll continue with that approach. Is there anything else you'd like us to do for him?
-[10:59:47 PM] User: Give him aspirin
-[10:59:48 PM] Assistant: I'll administer aspirin to Mr. Jones as part of his treatment plan. Is there anything else you'd like us to focus on?
-[11:01:34 PM] User: Fibrinolytic
-[11:01:35 PM] Assistant: Given Mr. Jones's condition, administering a fibrinolytic can be considered if he's not immediately headed for the cath lab. Please clarify if there's something more you'd like to do at this stage?
-[11:01:55 PM] User: Anticoagulation
-[11:01:56 PM] Assistant: Alright, we'll start anticoagulation therapy for Mr. Jones. What would you like to do next?`;
-
-  const handleCopyExample = async () => {
-    try {
-      await navigator.clipboard.writeText(exampleContent);
-      toast.success("Example copied to clipboard!");
-    } catch (err) {
-      toast.error("Failed to copy to clipboard");
-    }
-  };
-
-  async function handleGenerate() {
-    try {
-      setLoading(true);
-      const res = await fetch("/api/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ csv }),
-      });
-      if (!res.ok) throw new Error("OpenAI error");
-      const { id, aiNote } = await res.json();
-      setId(id);
-      setAiNote(aiNote);
-    } catch (e) {
-      toast.error((e as Error).message || "Something went wrong");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  return (
-    <>
-      <nav className="bg-transparent sticky top-0 z-50">
-        <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <div className="flex items-center">
-              <Link href="/" className="text-xl font-black text-white tracking-tight hover:text-gray-200 transition-colors">
-                Project SOAP
-              </Link>
-            </div>
-          </div>
-        </div>
-      </nav>
-      <main className="container mx-auto max-w-4xl space-y-8 py-12 px-4 sm:px-6 lg:px-8">
-      
-      <Card>
-        <h1 className="mb-4 text-xl font-semibold">Paste encounter log</h1>
-        <p className="mb-4 text-gray-600">
-          Paste the complete patient interaction into the space below.
-        </p>
-        <p className="text-sm font-medium text-gray-700 mb-2">Example of expected input:</p>
-        <div className="mb-4 p-3 bg-gray-50 rounded-md border-l-4 border-blue-400 relative">
-          <button
-            onClick={handleCopyExample}
-            className="absolute top-3 right-3 p-1 text-gray-500 hover:text-gray-700 hover:bg-gray-200 rounded transition-colors z-10"
-            title="Copy example to clipboard"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M16 1H4C2.9 1 2 1.9 2 3V17H4V3H16V1ZM19 5H8C6.9 5 6 5.9 6 7V21C6 22.1 6.9 23 8 23H19C20.1 23 21 22.1 21 21V7C21 5.9 20.1 5 19 5ZM19 21H8V7H19V21Z" fill="currentColor"/>
-            </svg>
-          </button>
-          <div className="relative">
-            <pre className="text-xs text-gray-600 font-mono whitespace-pre-wrap break-words overflow-y-scroll max-h-32 pr-8">
-{exampleContent}
-            </pre>
-            <div className="absolute bottom-0 left-0 right-0 h-4 bg-gradient-to-t from-gray-50 to-transparent pointer-events-none"></div>
-          </div>
-        </div>
-        <Textarea
-          rows={10}
-          placeholder="--- Module: History --- …"
-          value={csv}
-          onChange={(e) => setCsv(e.target.value)}
-          className="mb-4"
-        />
-        <Button loading={loading} onClick={handleGenerate} disabled={!csv}>
-          Generate SOAP
-        </Button>
-      </Card>
-
-      {loading && <Skeleton className="h-48 w-full" />}
-
-      {aiNote && (
-        <Card>
-          <h2 className="mb-2 text-lg font-semibold">AI-Generated SOAP</h2>
-          <SOAPNote content={aiNote} />
-          {id && (
-            <Link href={`/note/${id}`} className="mt-4 inline-block underline">
-              Edit & Review →
-            </Link>
-          )}
-        </Card>
-      )}
-    </main>
-    </>
-  );
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "default" | "secondary";
+  loading?: boolean;
 }
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", loading, children, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-bold uppercase transition-colors disabled:opacity-50",
+        variant === "default" &&
+          "bg-yellow-400 text-black hover:bg-yellow-500 focus-visible:ring-yellow-300",
+        variant === "secondary" &&
+          "bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700 focus-visible:ring-gray-300 dark:focus-visible:ring-gray-600",
+        className
+      )}
+      disabled={loading || props.disabled}
+      {...props}
+    >
+      {loading && <span className="animate-spin h-4 w-4 border-2 border-current border-t-transparent rounded-full" />}
+      {children}
+    </button>
+  )
+);
+Button.displayName = "Button";
+</file>
+
+<file path="src/app/globals.css">
+@import "tailwindcss";
+
+:root {
+  --background: #ffffff;
+  --foreground: #171717;
+  --card-background: #ffffff;
+  --card-foreground: #171717;
+  --border: #e5e7eb;
+  --input-border: #d1d5db;
+  --muted: #f9fafb;
+  --muted-foreground: #6b7280;
+  --accent: #f3f4f6;
+  --accent-foreground: #1f2937;
+  --primary: #1f2937;
+  --primary-foreground: #ffffff;
+  --secondary: #f3f4f6;
+  --secondary-foreground: #1f2937;
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --font-sans: var(--font-manrope);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #0a0a0a;
+    --foreground: #ededed;
+    --card-background: #1a1a1a;
+    --card-foreground: #ededed;
+    --border: #374151;
+    --input-border: #4b5563;
+    --muted: #111827;
+    --muted-foreground: #9ca3af;
+    --accent: #1f2937;
+    --accent-foreground: #f3f4f6;
+    --primary: #f3f4f6;
+    --primary-foreground: #1f2937;
+    --secondary: #374151;
+    --secondary-foreground: #f3f4f6;
+  }
+}
+
+body {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: var(--foreground);
+  font-family: var(--font-manrope), system-ui, sans-serif;
+  min-height: 100vh;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
+  }
+}
+
+/* Enhanced SOAP Note Formatting */
+.soap-note {
+  line-height: 1.7;
+  font-feature-settings: "kern" 1, "liga" 1;
+}
+
+.soap-note h2 {
+  letter-spacing: -0.025em;
+}
+
+.soap-note p {
+  text-align: justify;
+  hyphens: auto;
+}
+
+.soap-note ul {
+  list-style: none;
+}
+
+.soap-note strong {
+  font-weight: 600;
+}
+
+/* Improved readability for medical content */
+.soap-note code {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Better spacing for nested content */
+.soap-note li p {
+  margin-bottom: 0.5rem;
+}
+
+.soap-note li:last-child {
+  margin-bottom: 0;
+}
+</file>
+
+<file path="README.md">
+# 🧼 Project SOAP
+
+An AI-powered medical documentation tool that generates and reviews SOAP notes from patient encounter transcripts.  
+Built with **Next.js**, **OpenAI GPT-4o**, and **Tailwind CSS**.
+
+---
+
+## How It Works
+
+### 1. Generate SOAP Note
+- **Input**: Paste a full patient encounter transcript formatted as user, assistant. Be sure to include all relevant modules.
+- The app parses the dialogue into clinician/patient turns (`src/lib/parseCsv.ts`).
+- A **system prompt** (`src/lib/prompts.ts`) instructs the AI to produce a concise, markdown-formatted SOAP note.
+- The transcript + prompt are sent to the **`/api/generate`** endpoint, which calls the OpenAI API.
+- The AI-generated SOAP note is stored in memory (`src/lib/store.ts`) and displayed to the user.
+
+### 2. Edit & Submit
+- Users can click **"Edit & Review"** to refine the SOAP note.
+- Their edits are saved as the **student note** for the encounter.
+
+### 3. AI Review & Grading
+- On submission, the **`/api/review`** endpoint:
+  - Retrieves the original AI note and the student-edited note.
+  - Uses a **PDQI-9 scoring rubric** with clinical appropriateness rules (`src/app/api/review/route.ts`).
+  - Compares both notes against the encounter transcript.
+  - Returns JSON with:
+    - **Scores** for each PDQI-9 dimension.
+    - **Delta scores** (student vs. AI).
+    - **Per-dimension change comments**.
+    - **Overall feedback**.
+
+### 4. Feedback Display
+- The UI presents a detailed breakdown:
+  - Scores and deltas per dimension.
+  - Specific snippets causing score changes.
+  - Global comments for improvement.
+
+---
+
+## Tech Stack
+
+- **Framework**: Next.js 15
+- **Styling**: Tailwind CSS
+- **AI**: OpenAI GPT-4o / GPT-4o-mini
+- **Parsing**: PapaParse for CSV input
+- **State**: In-memory store (Map)
+- **UI Components**: Custom + Tailwind utilities
+- **Icons**: Lucide React
+- **Notifications**: Sonner
+
+---
+
+## Local Development
+
+```bash
+# Install dependencies
+npm install
+
+# Run development server
+npm run dev
+
+# Open in browser
+http://localhost:3000
 </file>
 
 <file path="src/app/api/review/route.ts">
@@ -1113,6 +1318,238 @@ export async function POST(req: Request) {
 }
 </file>
 
+<file path="src/app/page.tsx">
+"use client";
+import { useState } from "react";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SOAPNote } from "@/components/ui/soap-note";
+import { toast } from "sonner";
+import Link from "next/link";
+import { Home as HomeIcon, FileText } from "lucide-react";
+
+export default function Home() {
+  const [csv, setCsv] = useState("");
+  const [aiNote, setAiNote] = useState("");
+  const [id, setId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const exampleContent = `--- Module: History ---
+[10:28:26 PM] User: When did it start?
+[10:28:27 PM] Assistant: Well, it began about a week ago.
+[10:28:42 PM] User: Describe the pain
+[10:28:42 PM] Assistant: It's a heavy, tight pressure right in the center of my chest.
+[10:28:54 PM] User: How long does it last?
+[10:28:55 PM] Assistant: It lasts for around 5 to 10 minutes before it eases up with rest.
+[10:29:54 PM] User: What's your medical history
+[10:29:54 PM] Assistant: Umm, can you be more specific about what you're asking?
+[10:30:42 PM] User: Do you have any ongoing disease?
+[10:30:43 PM] Assistant: I've been managing hypertension and cholesterol with medication.
+[10:31:05 PM] User: Ever had an MI?
+[10:31:06 PM] Assistant: I'm not quite sure what "MI" means. Could you explain that to me?
+[10:31:17 PM] User: Ever had a heart attack?
+[10:31:18 PM] Assistant: No, I've never had a heart attack before.
+[10:31:34 PM] User: Ever had surgery?
+[10:31:34 PM] Assistant: No, I've never had any surgery.
+[10:31:41 PM] User: Allergies?
+[10:31:42 PM] Assistant: No, I don't have any known allergies.
+[10:32:08 PM] User: Which meds are you currently taking?
+[10:32:08 PM] Assistant: I'm taking Hydrochlorothiazide for blood pressure and Atorvastatin for cholesterol.
+[10:32:33 PM] User: What are your vitals?
+[10:32:34 PM] Assistant: I'm not sure exactly. The doctors usually check them during my appointments, but I don't remember the specific numbers.
+[10:33:17 PM] User: Any relevant family history?
+[10:33:18 PM] Assistant: Yeah, my father had a heart attack at the age of 52.
+[10:33:41 PM] User: Do you regularly consult with a cardiologist?
+[10:33:41 PM] Assistant: I try to follow up regularly with my doctor, but it's been about six months since my last check-up.
+[10:34:05 PM] User: Does the pain irradiate?
+[10:34:06 PM] Assistant: Yes, sometimes it spreads and radiates into my left arm.
+[10:34:24 PM] User: What are you doing when the pain appears?
+[10:34:25 PM] Assistant: It usually happens during physical activity, like climbing stairs or hurrying somewhere.
+[10:35:26 PM] User: Have you had any recent lab workup
+[10:35:27 PM] Assistant: No, I haven't had any recent lab work done.
+[10:36:09 PM] User: What does your diet look like
+[10:36:10 PM] Assistant: Well, I try to eat healthy, but there are days when I skip meals or grab something quick and unhealthy because of work.
+[10:36:23 PM] User: What are your habits?
+[10:36:24 PM] Assistant: I jog regularly in the mornings before work, and I'm also a moderate smoker.
+--- Module: Differential Diagnosis ---
+[10:37:27 PM] User: Unstable angina
+[10:37:28 PM] Assistant: Why do you think unstable angina is on your differential for Mr. Jones?
+[10:38:33 PM] User: The pain lasts less than 40min, it alleviates with rest, he has a history of high cholesterol
+[10:38:36 PM] Assistant: Yes, unstable angina is a strong consideration here. The chest pain lasting 5 to 10 minutes and resolving with rest is characteristic of angina. His history of high cholesterol and hypertension, along with a family history of heart disease, puts him at increased risk for coronary artery disease. What is the second condition on your differential?
+[10:39:45 PM] User: We should rule out a myocardial infarction
+[10:39:48 PM] Assistant: Consider using broad terms. "Acute Coronary Syndrome", which includes Myocardial Infarction or Unstable Angina, is a good way to phrase this possibility. Since you've already mentioned Unstable Angina, let's focus on another separate condition that could be causing his symptoms. What's another differential diagnosis you are considering?
+[10:42:33 PM] User: Should we be considering a pulmonary embolism?
+[10:42:35 PM] Assistant: Yes, a pulmonary embolism is a valid consideration. Given his recent travel history and periods of immobility, combined with smoking, they are risk factors for venous thromboembolism. Sudden onset chest pain could point towards a pulmonary embolism. What's the third condition on your differential?
+[10:43:11 PM] User: Panic attacks
+[10:43:13 PM] Assistant: While panic attacks can present with chest pain, in this scenario, we should prioritize ruling out potentially life-threatening cardiac or pulmonary conditions first. Could you suggest another condition that could be causing his symptoms?
+[10:43:38 PM] User: Can you guide my thought?
+[10:43:40 PM] Assistant: Certainly. Consider conditions that could involve inflammation around the heart or increases in pressure on the heart. These could be attributed to recent respiratory symptoms or a history of chronic tension and stress, affecting the heart or its surrounding structures. What's another diagnosis you might consider?
+[10:43:56 PM] User: Myocarditis
+[10:43:58 PM] Assistant: Myocarditis is a reasonable consideration given his recent cold, as viral infections can sometimes lead to inflammation of the heart muscle. This could cause chest pain and explain his symptoms. Now that we've discussed three conditions, let's proceed with the case.
+--- Module: Results Interpretation ---
+[10:46:44 PM] User: Normal rate - between 100 and 75, maybe high 80s.
+[10:46:45 PM] Assistant: Hmm, I would suggest double-checking that rate. Try to determine it more precisely.
+[10:48:26 PM] User: 75 bpm
+[10:48:27 PM] Assistant: Good, that rate is within normal range. What about the rhythm? Do you notice anything specific?
+[10:48:38 PM] User: Sinus rhythm
+[10:48:39 PM] Assistant: Correct, it is a regular sinus rhythm. Are there any noticeable ST changes on the EKG?
+[10:48:48 PM] User: No ST changes
+[10:48:49 PM] Assistant: Great, that's correct: there are no ST changes. Please continue to the next step to continue with the case.
+--- Module: Re-Evaluation ---
+[10:50:14 PM] User: Looks like and anterior STEMI
+[10:50:15 PM] Assistant: Alright, recognizing those changes on the EKG is important. What would you like us to do next for Mr. Jones?
+[10:50:40 PM] User: Prep him for cath lab
+[10:50:41 PM] Assistant: Understood, I'll notify the cath lab and ensure they're ready for Mr. Jones. What else would you like to address while we're preparing him?
+[10:50:58 PM] User: What's his BP?
+[10:50:59 PM] Assistant: Let me check that for you. Mr. Jones's blood pressure is currently 160/95. What would you like to do next?
+[10:51:19 PM] User: Let's give him labetalol to lower it
+[10:51:20 PM] Assistant: We can certainly work on managing his blood pressure. I'll prepare the labetalol for administration. Is there anything else you would like to address for Mr. Jones right now?
+[10:51:46 PM] User: Do we have the troponin value?
+[10:51:47 PM] Assistant: Let's see... Mr. Jones's initial troponin level is elevated, indicating cardiac involvement. What would you like to do with this information?
+[10:52:47 PM] User: Let's hook him to a monitor
+[10:52:49 PM] Assistant: We'll get Mr. Jones on the monitor right away to keep a close eye on his vitals. What would you like to do next?
+[10:53:04 PM] User: What are his vitals now?
+[10:53:05 PM] Assistant: Okay, let me check that for you. Mr. Jones's current vitals are:
+- Blood pressure: 160/95
+- Heart rate: 100 beats per minute
+- Respiratory rate: 20 breaths per minute
+- Oxygen saturation: 96% on room air
+Is there anything specific you'd like to do with this information?
+[10:53:46 PM] User: Let's give his sublingual nitro
+[10:53:48 PM] Assistant: Alright, I'll administer the sublingual nitroglycerin to help with his chest pain. What would you like us to focus on next?
+[10:54:15 PM] User: Let's have a crash cart ready
+[10:54:16 PM] Assistant: We'll make sure the crash cart is at the ready, just in case. What other steps would you like us to take for Mr. Jones?
+[10:55:34 PM] User: Guide my thought
+[10:55:35 PM] Assistant: I understand this can feel like a lot to manage. Your focus on ensuring Mr. Jones's stability is key. Please let me know how you'd like to proceed with his care.
+[10:55:58 PM] User: Should we give him some fluids?
+[10:55:59 PM] Assistant: We can start an IV line for Mr. Jones, which will allow us to give fluids if needed. Would you like us to proceed with establishing IV access and anything else?
+[10:56:18 PM] User: Stablish an IV
+[10:56:19 PM] Assistant: I'll go ahead and establish IV access for Mr. Jones. Is there anything else you'd like to address for his ongoing care?
+[10:56:36 PM] User: Notify family
+[10:56:37 PM] Assistant: I'll arrange for someone to notify Mr. Jones's family about his condition and that he's being prepared for further treatment. Is there anything else you'd like to do right now?
+[10:57:09 PM] User: Take another ekg
+[10:57:11 PM] Assistant: Alright, we'll go ahead and perform another EKG to monitor any changes. Meanwhile, is there anything else you would like to address with Mr. Jones?
+[10:57:45 PM] User: Do an echo
+[10:57:46 PM] Assistant: An echo can provide valuable information about Mr. Jones's heart function. I'll make arrangements for an echocardiogram. In the meantime, is there anything else you'd like to do?
+[10:58:02 PM] User: Any suggestions?
+[10:58:03 PM] Assistant: I'm here to assist with what you decide is best for Mr. Jones. You've made some important decisions so far. Please let me know how you'd like to continue with his care.
+[10:59:04 PM] User: Let's control the rate
+[10:59:05 PM] Assistant: To control Mr. Jones's heart rate, we can consider medications like beta-blockers which you've already mentioned, we'll continue with that approach. Is there anything else you'd like us to do for him?
+[10:59:47 PM] User: Give him aspirin
+[10:59:48 PM] Assistant: I'll administer aspirin to Mr. Jones as part of his treatment plan. Is there anything else you'd like us to focus on?
+[11:01:34 PM] User: Fibrinolytic
+[11:01:35 PM] Assistant: Given Mr. Jones's condition, administering a fibrinolytic can be considered if he's not immediately headed for the cath lab. Please clarify if there's something more you'd like to do at this stage?
+[11:01:55 PM] User: Anticoagulation
+[11:01:56 PM] Assistant: Alright, we'll start anticoagulation therapy for Mr. Jones. What would you like to do next?`;
+
+  const handleCopyExample = async () => {
+    try {
+      await navigator.clipboard.writeText(exampleContent);
+      toast.success("Example copied to clipboard!");
+    } catch (err) {
+      toast.error("Failed to copy to clipboard");
+    }
+  };
+
+  async function handleGenerate() {
+    try {
+      setLoading(true);
+      const res = await fetch("/api/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ csv }),
+      });
+      if (!res.ok) throw new Error("OpenAI error");
+      const { id, aiNote } = await res.json();
+      setId(id);
+      setAiNote(aiNote);
+    } catch (e) {
+      toast.error((e as Error).message || "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <nav className="bg-black/90 backdrop-blur-sm sticky top-0 z-[100]">
+        <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <Link href="/" className="text-xl font-black text-white tracking-tight hover:text-gray-200 transition-colors flex items-center">
+                <span className="mr-2">🧼</span>
+                Project SOAP
+              </Link>
+            </div>
+            <div className="flex items-center space-x-6">
+              <Link href="/" className="text-white hover:text-gray-200 transition-colors font-medium flex items-center">
+                <HomeIcon size={20} />
+              </Link>
+              <Link href="/documentation" className="text-white hover:text-gray-200 transition-colors flex items-center">
+                <FileText size={20} />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </nav>
+      <main className="container mx-auto max-w-4xl space-y-8 py-12 px-4 sm:px-6 lg:px-8">
+      
+      <Card>
+        <h1 className="mb-4 text-xl font-semibold text-gray-900 dark:text-gray-100">Paste encounter log</h1>
+        <p className="mb-4 text-gray-600 dark:text-gray-400">
+          Paste the complete patient interaction into the space below.
+        </p>
+        <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Example of expected input:</p>
+        <div className="mb-4 p-3 bg-gray-50 dark:bg-gray-800 rounded-md border-l-4 border-blue-400 dark:border-blue-500 relative">
+          <button
+            onClick={handleCopyExample}
+            className="absolute top-3 right-3 p-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors z-10"
+            title="Copy example to clipboard"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M16 1H4C2.9 1 2 1.9 2 3V17H4V3H16V1ZM19 5H8C6.9 5 6 5.9 6 7V21C6 22.1 6.9 23 8 23H19C20.1 23 21 22.1 21 21V7C21 5.9 20.1 5 19 5ZM19 21H8V7H19V21Z" fill="currentColor"/>
+            </svg>
+          </button>
+          <div className="relative">
+            <pre className="text-xs text-gray-600 dark:text-gray-400 font-mono whitespace-pre-wrap break-words overflow-y-scroll max-h-32 pr-8">
+{exampleContent}
+            </pre>
+            <div className="absolute bottom-0 left-0 right-0 h-4 bg-gradient-to-t from-gray-50 dark:from-gray-800 to-transparent pointer-events-none"></div>
+          </div>
+        </div>
+        <Textarea
+          rows={10}
+          placeholder="--- Module: History --- …"
+          value={csv}
+          onChange={(e) => setCsv(e.target.value)}
+          className="mb-4"
+        />
+        <Button loading={loading} onClick={handleGenerate} disabled={!csv}>
+          Generate SOAP
+        </Button>
+      </Card>
+
+      {loading && <Skeleton className="h-48 w-full" />}
+
+      {aiNote && (
+        <Card>
+          <h2 className="mb-2 text-lg font-semibold text-gray-900 dark:text-gray-100">AI-Generated SOAP</h2>
+          <SOAPNote content={aiNote} />
+          {id && (
+            <Link href={`/note/${id}`} className="mt-4 inline-block underline text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300">
+              Edit & Review →
+            </Link>
+          )}
+        </Card>
+      )}
+    </main>
+    </>
+  );
+}
+</file>
+
 <file path="src/app/note/[id]/page.tsx">
 "use client";
 import React, { useEffect, useState } from "react";
@@ -1124,6 +1561,7 @@ import { SOAPNote } from "@/components/ui/soap-note";
 import { toast } from "sonner";
 import { Review, ReviewChange } from "@/types";
 import Link from "next/link";
+import { Home, FileText } from "lucide-react";
 
 // Review component for displaying feedback
 function ReviewDisplay({ review }: { review: Review }) {
@@ -1141,16 +1579,16 @@ function ReviewDisplay({ review }: { review: Review }) {
 
 
   const getDeltaColor = (delta: number) => {
-    if (delta >= 2) return "text-green-600 bg-green-50";
-    if (delta >= 0) return "text-yellow-600 bg-yellow-50";
+    if (delta >= 2) return "text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20";
+    if (delta >= 0) return "text-yellow-600 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-900/20";
 
-    return "text-red-600 bg-red-50";
+    return "text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20";
   };
 
   const getImpactColor = (impact: string) => {
-    if (impact === "improved") return "text-green-600 bg-green-100";
-    if (impact === "worsened") return "text-red-600 bg-red-100";
-    return "text-gray-600 bg-gray-100";
+    if (impact === "improved") return "text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30";
+    if (impact === "worsened") return "text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/30";
+    return "text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-800";
   };
 
   // Group changes by dimension
@@ -1165,12 +1603,12 @@ function ReviewDisplay({ review }: { review: Review }) {
 
       {/* PDQI-9 Detailed Scoring */}
       <div className="space-y-4">
-        <h3 className="font-semibold text-lg">PDQI-9 Detailed Scoring</h3>
+        <h3 className="font-semibold text-lg text-gray-900 dark:text-gray-100">PDQI-9 Detailed Scoring</h3>
         
         {/* Score Summary Table */}
-        <div className="border rounded-lg overflow-hidden">
-          <div className="bg-gray-50 p-3 border-b">
-            <div className="grid grid-cols-4 gap-2 text-sm font-medium text-gray-700">
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+          <div className="bg-gray-50 dark:bg-gray-800 p-3 border-b border-gray-200 dark:border-gray-700">
+            <div className="grid grid-cols-4 gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
               <div>Dimension</div>
               <div className="text-center">Baseline</div>
               <div className="text-center">Student</div>
@@ -1184,12 +1622,12 @@ function ReviewDisplay({ review }: { review: Review }) {
             const deltaScore = review.delta_scores?.[key] || 0;
             
             return (
-              <div key={key} className="p-3 border-b border-gray-100 last:border-b-0">
+              <div key={key} className="p-3 border-b border-gray-100 dark:border-gray-700 last:border-b-0 bg-white dark:bg-gray-900">
                 <div className="grid grid-cols-4 gap-2 text-sm">
-                  <div className="font-medium">{name}</div>
-                  <div className="text-center text-gray-600">{baselineScore}/5</div>
-                  <div className="text-center text-gray-600">{studentScore}/5</div>
-                  <div className={`text-center font-semibold ${getDeltaColor(deltaScore)}`}>
+                  <div className="font-medium text-gray-900 dark:text-gray-100">{name}</div>
+                  <div className="text-center text-gray-600 dark:text-gray-400">{baselineScore}/5</div>
+                  <div className="text-center text-gray-600 dark:text-gray-400">{studentScore}/5</div>
+                  <div className={`text-center font-semibold px-2 py-1 rounded ${getDeltaColor(deltaScore)}`}>
                     {deltaScore > 0 ? '+' : ''}{deltaScore}
                   </div>
                 </div>
@@ -1206,9 +1644,9 @@ function ReviewDisplay({ review }: { review: Review }) {
           if (dimensionChanges.length === 0) return null;
           
           return (
-            <div key={key} className={`border rounded-lg p-4 ${getDeltaColor(deltaScore)}`}>
+            <div key={key} className={`border border-gray-200 dark:border-gray-700 rounded-lg p-4 ${getDeltaColor(deltaScore)}`}>
               <div className="flex items-center justify-between mb-3">
-                <h4 className="font-medium">{name}</h4>
+                <h4 className="font-medium text-gray-900 dark:text-gray-100">{name}</h4>
                 <span className="font-semibold text-lg">
                   {deltaScore > 0 ? '+' : ''}{deltaScore}
                 </span>
@@ -1217,16 +1655,16 @@ function ReviewDisplay({ review }: { review: Review }) {
               {/* Changes for this dimension */}
               <div className="space-y-2">
                 {dimensionChanges.map((change: ReviewChange, index: number) => (
-                  <div key={index} className="bg-white bg-opacity-50 rounded p-3 border-l-4 border-gray-300">
+                  <div key={index} className="bg-white dark:bg-gray-800/50 bg-opacity-50 rounded p-3 border-l-4 border-gray-300 dark:border-gray-600">
                     <div className="flex items-center gap-2 mb-1">
                       <span className={`font-medium text-sm px-2 py-1 rounded ${getImpactColor(change.impact)}`}>
                         {change.impact}
                       </span>
-                      <span className="text-xs text-gray-600 font-mono bg-gray-100 px-2 py-1 rounded">
+                      <span className="text-xs text-gray-600 dark:text-gray-400 font-mono bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded">
                         &quot;{change.snippet}&quot;
                       </span>
                     </div>
-                    <p className="text-sm text-gray-700">{change.comment}</p>
+                    <p className="text-sm text-gray-700 dark:text-gray-300">{change.comment}</p>
                   </div>
                 ))}
               </div>
@@ -1237,9 +1675,9 @@ function ReviewDisplay({ review }: { review: Review }) {
 
       {/* Global Comment */}
       {review.global_comment && (
-        <div className="border rounded-lg p-4 bg-blue-50">
-          <h3 className="font-semibold text-lg mb-2">Overall Feedback</h3>
-          <p className="text-gray-700">{review.global_comment}</p>
+        <div className="border border-blue-200 dark:border-blue-700 rounded-lg p-4 bg-blue-50 dark:bg-blue-900/20">
+          <h3 className="font-semibold text-lg mb-2 text-gray-900 dark:text-gray-100">Overall Feedback</h3>
+          <p className="text-gray-700 dark:text-gray-300">{review.global_comment}</p>
         </div>
       )}
     </div>
@@ -1284,12 +1722,21 @@ export default function NotePage({ params }: { params: Promise<{ id: string }> }
 
   return (
     <>
-      <nav className="bg-transparent sticky top-0 z-50">
+      <nav className="bg-black/90 backdrop-blur-sm sticky top-0 z-[100]">
         <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">
-              <Link href="/" className="text-xl font-black text-white tracking-tight hover:text-gray-200 transition-colors">
+              <Link href="/" className="text-xl font-black text-white tracking-tight hover:text-gray-200 transition-colors flex items-center">
+                <span className="mr-2">🧼</span>
                 Project SOAP
+              </Link>
+            </div>
+            <div className="flex items-center space-x-6">
+              <Link href="/" className="text-white hover:text-gray-200 transition-colors flex items-center">
+                <Home size={20} />
+              </Link>
+              <Link href="/documentation" className="text-white hover:text-gray-200 transition-colors flex items-center">
+                <FileText size={20} />
               </Link>
             </div>
           </div>
@@ -1301,12 +1748,12 @@ export default function NotePage({ params }: { params: Promise<{ id: string }> }
       ) : (
         <div className="grid gap-6 md:grid-cols-2">
           <Card className="overflow-auto">
-            <h2 className="mb-2 text-lg font-semibold">AI SOAP (read-only)</h2>
+            <h2 className="mb-2 text-lg font-semibold text-gray-900 dark:text-gray-100">AI SOAP (read-only)</h2>
             <SOAPNote content={aiNote} />
           </Card>
 
           <Card>
-            <h2 className="mb-2 text-lg font-semibold">Your SOAP (edit)</h2>
+            <h2 className="mb-2 text-lg font-semibold text-gray-900 dark:text-gray-100">Your SOAP (edit)</h2>
             <Textarea
               rows={18}
               value={student}

--- a/src/app/api/review-prompt/route.ts
+++ b/src/app/api/review-prompt/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/store";
+import { defaultReviewPrompt } from "@/lib/reviewPrompt";
+
+// GET: ?id=<encId> → { id, prompt: string | null, defaultPrompt: string }
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const id = url.searchParams.get("id");
+  
+  if (!id) {
+    return NextResponse.json({ error: "Missing id parameter" }, { status: 400 });
+  }
+  
+  const enc = db.get(id);
+  if (!enc) {
+    return NextResponse.json({ error: "Encounter not found" }, { status: 404 });
+  }
+  
+  return NextResponse.json({
+    id,
+    prompt: enc.reviewPrompt ?? null,
+    defaultPrompt: defaultReviewPrompt
+  });
+}
+
+// PUT: body { id: string, prompt: string }
+export async function PUT(req: Request) {
+  try {
+    const { id, prompt } = await req.json();
+    
+    if (!id || typeof prompt !== "string") {
+      return NextResponse.json({ error: "Missing or invalid id or prompt" }, { status: 400 });
+    }
+    
+    const trimmedPrompt = prompt.trim();
+    
+    // Cap at 12,000 chars
+    if (trimmedPrompt.length > 12_000) {
+      return NextResponse.json({ error: "Prompt exceeds 12,000 character limit" }, { status: 413 });
+    }
+    
+    const enc = db.get(id);
+    if (!enc) {
+      return NextResponse.json({ error: "Encounter not found" }, { status: 404 });
+    }
+    
+    enc.reviewPrompt = trimmedPrompt;
+    enc.reviewPromptEditedAt = new Date();
+    
+    return NextResponse.json({ 
+      id, 
+      prompt: trimmedPrompt,
+      editedAt: enc.reviewPromptEditedAt 
+    });
+    
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+}
+
+// DELETE: body { id: string }
+export async function DELETE(req: Request) {
+  try {
+    const { id } = await req.json();
+    
+    if (!id) {
+      return NextResponse.json({ error: "Missing id" }, { status: 400 });
+    }
+    
+    const enc = db.get(id);
+    if (!enc) {
+      return NextResponse.json({ error: "Encounter not found" }, { status: 404 });
+    }
+    
+    delete enc.reviewPrompt;
+    delete enc.reviewPromptEditedAt;
+    
+    return NextResponse.json({ 
+      id,
+      prompt: null 
+    });
+    
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+} 

--- a/src/app/api/review/route.ts
+++ b/src/app/api/review/route.ts
@@ -2,71 +2,30 @@ import { NextResponse } from "next/server";
 import { openai } from "@/lib/openai";
 import { db } from "@/lib/store";
 import { clipText } from "@/lib/clipText";
-
-const reviewPrompt = `
-
-You are an attending physician using the **PDQI-9** rubric with emphasis on **clinical appropriateness**.
-
-Notes:
-• NOTE_A = baseline AI-generated SOAP (reference)  
-• NOTE_B = student-edited version
-
-**CRITICAL: Use the CONTEXT transcript to judge clinical appropriateness. Inappropriate treatments/medications for the actual clinical scenario should receive LOW scores (1-2).**
-
-Step 1 – Score BOTH notes (Likert 1-5 scale)
-  • **Scoring Guidelines:**
-    - **5**: Excellent, clinically appropriate, evidence-based
-    - **4**: Good, mostly appropriate with minor issues
-    - **3**: Adequate, some concerns but not harmful
-    - **2**: Poor, inappropriate for clinical scenario or potentially harmful
-    - **1**: Dangerous, contraindicated, or completely inappropriate
-
-  • **Key Dimensions with Clinical Focus:**
-    - **accurate**: Factually correct AND clinically appropriate for the case
-    - **useful**: Helpful for patient care AND safe/appropriate treatments
-    - **thorough**: Complete relevant info WITHOUT inappropriate additions
-    - **up_to_date**: Current guidelines AND appropriate for this patient
-    - **organized/comprehensible/succinct/synthesized/consistent**: Standard PDQI-9
-
-  • **PENALIZE HEAVILY**: 
-    - Wrong medications for the condition (e.g., antibiotics for MI)
-    - Inappropriate treatments that don't match the clinical scenario
-    - Dangerous or contraindicated interventions
-
-Step 2 – Delta  
-  • delta = score_B − score_A (range −4→+4).  
-  • overall_delta = sum of deltas (range −36→+36).
-
-Step 3 – Edit analysis  
-  • **REQUIRED**: Create a "changes" entry for EVERY dimension with a non-zero delta.  
-  • If delta ≠ 0, you MUST explain why that dimension score changed.  
-  • For each non-zero delta:  
-      – \`dimension\` name (exact PDQI-9 dimension that changed)  
-      – \`impact\` improved | worsened | neutral  
-      – \`snippet\` ≤20 words (specific text that caused the change)  
-      – \`comment\` coaching ≤25 words explaining WHY the score changed
-
-Return STRICT JSON only:
-
-{
-  "baseline_scores":    { "up_to_date":int, "accurate":int, "thorough":int, "useful":int, "organized":int, "comprehensible":int, "succinct":int, "synthesized":int, "consistent":int },
-  "student_scores":     { "up_to_date":int, "accurate":int, "thorough":int, "useful":int, "organized":int, "comprehensible":int, "succinct":int, "synthesized":int, "consistent":int },
-  "delta_scores":       { "up_to_date":int, "accurate":int, "thorough":int, "useful":int, "organized":int, "comprehensible":int, "succinct":int, "synthesized":int, "consistent":int },
-  "overall_delta": int,
-  "changes": [
-     { "dimension":str, "impact":str, "snippet":str, "comment":str }
-  ],
-
-  "global_comment": str
-}`;
+import { defaultReviewPrompt } from "@/lib/reviewPrompt";
 
 export async function POST(req: Request) {
-  const { id, studentNote } = await req.json();
+  const { id, studentNote, gradingPrompt } = await req.json();
   const enc = db.get(id);
   if (!enc?.aiNote) {
     return NextResponse.json({ error: "Encounter not found" }, { status: 404 });
   }
   enc.studentNote = studentNote;
+
+  // Resolve prompt in order: inline → saved → default
+  let promptToUse = defaultReviewPrompt;
+  
+  if (gradingPrompt) {
+    // Inline override - apply same validation
+    const trimmedInlinePrompt = gradingPrompt.trim();
+    if (trimmedInlinePrompt.length > 12_000) {
+      return NextResponse.json({ error: "Grading prompt exceeds 12,000 character limit" }, { status: 413 });
+    }
+    promptToUse = trimmedInlinePrompt;
+  } else if (enc.reviewPrompt) {
+    // Use saved prompt for this encounter
+    promptToUse = enc.reviewPrompt;
+  }
 
   const transcript = clipText(enc.csv);
   console.log("Transcript chars:", transcript.length);
@@ -74,7 +33,7 @@ export async function POST(req: Request) {
   const messages = [
     {
       role: "system" as const,
-      content: reviewPrompt,
+      content: promptToUse,
     },
     {
       role: "user" as const,

--- a/src/app/documentation/page.tsx
+++ b/src/app/documentation/page.tsx
@@ -326,6 +326,31 @@ export async function POST(req: Request) {
                      </div>
                    </details>
                  </div>
+                 
+                 {/* Custom grading prompt subsection */}
+                 <div className="ml-11 mt-6">
+                   <h4 className="text-lg font-semibold mb-4 text-gray-800 dark:text-gray-200">Custom Grading Prompts</h4>
+                   <div className="space-y-3">
+                     <div className="flex items-start space-x-3">
+                       <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                       <div>
+                         <p className="text-gray-700 dark:text-gray-300">You can open <strong>Edit grading prompt</strong> on the note page to customize how your SOAP notes are evaluated.</p>
+                       </div>
+                     </div>
+                     <div className="flex items-start space-x-3">
+                       <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                       <div>
+                         <p className="text-gray-700 dark:text-gray-300">Custom prompts are saved per encounter and persist during your session. Use <strong>Reset to default</strong> to return to the standard PDQI-9 rubric.</p>
+                       </div>
+                     </div>
+                     <div className="flex items-start space-x-3">
+                       <div className="w-2 h-2 bg-gray-400 dark:bg-gray-500 rounded-full mt-2 flex-shrink-0"></div>
+                       <div>
+                         <p className="text-gray-700 dark:text-gray-300">The default rubric focuses on <strong>PDQI-9 clinical appropriateness</strong>, emphasizing safe and evidence-based care that matches the patient encounter.</p>
+                       </div>
+                     </div>
+                   </div>
+                 </div>
                </div>
 
                <div>

--- a/src/lib/reviewPrompt.ts
+++ b/src/lib/reviewPrompt.ts
@@ -1,0 +1,56 @@
+export const defaultReviewPrompt = `
+
+You are an attending physician using the **PDQI-9** rubric with emphasis on **clinical appropriateness**.
+
+Notes:
+• NOTE_A = baseline AI-generated SOAP (reference)  
+• NOTE_B = student-edited version
+
+**CRITICAL: Use the CONTEXT transcript to judge clinical appropriateness. Inappropriate treatments/medications for the actual clinical scenario should receive LOW scores (1-2).**
+
+Step 1 – Score BOTH notes (Likert 1-5 scale)
+  • **Scoring Guidelines:**
+    - **5**: Excellent, clinically appropriate, evidence-based
+    - **4**: Good, mostly appropriate with minor issues
+    - **3**: Adequate, some concerns but not harmful
+    - **2**: Poor, inappropriate for clinical scenario or potentially harmful
+    - **1**: Dangerous, contraindicated, or completely inappropriate
+
+  • **Key Dimensions with Clinical Focus:**
+    - **accurate**: Factually correct AND clinically appropriate for the case
+    - **useful**: Helpful for patient care AND safe/appropriate treatments
+    - **thorough**: Complete relevant info WITHOUT inappropriate additions
+    - **up_to_date**: Current guidelines AND appropriate for this patient
+    - **organized/comprehensible/succinct/synthesized/consistent**: Standard PDQI-9
+
+  • **PENALIZE HEAVILY**: 
+    - Wrong medications for the condition (e.g., antibiotics for MI)
+    - Inappropriate treatments that don't match the clinical scenario
+    - Dangerous or contraindicated interventions
+
+Step 2 – Delta  
+  • delta = score_B − score_A (range −4→+4).  
+  • overall_delta = sum of deltas (range −36→+36).
+
+Step 3 – Edit analysis  
+  • **REQUIRED**: Create a "changes" entry for EVERY dimension with a non-zero delta.  
+  • If delta ≠ 0, you MUST explain why that dimension score changed.  
+  • For each non-zero delta:  
+      – \`dimension\` name (exact PDQI-9 dimension that changed)  
+      – \`impact\` improved | worsened | neutral  
+      – \`snippet\` ≤20 words (specific text that caused the change)  
+      – \`comment\` coaching ≤25 words explaining WHY the score changed
+
+Return STRICT JSON only:
+
+{
+  "baseline_scores":    { "up_to_date":int, "accurate":int, "thorough":int, "useful":int, "organized":int, "comprehensible":int, "succinct":int, "synthesized":int, "consistent":int },
+  "student_scores":     { "up_to_date":int, "accurate":int, "thorough":int, "useful":int, "organized":int, "comprehensible":int, "succinct":int, "synthesized":int, "consistent":int },
+  "delta_scores":       { "up_to_date":int, "accurate":int, "thorough":int, "useful":int, "organized":int, "comprehensible":int, "succinct":int, "synthesized":int, "consistent":int },
+  "overall_delta": int,
+  "changes": [
+     { "dimension":str, "impact":str, "snippet":str, "comment":str }
+  ],
+
+  "global_comment": str
+}`; 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -8,6 +8,8 @@ export interface Encounter {
   studentNote?: string;
   reviewJson?: Review;
   createdAt: Date;
+  reviewPrompt?: string;
+  reviewPromptEditedAt?: Date;
 }
 
 // Use a single Map instance attached to globalThis


### PR DESCRIPTION
# feat: Editable grading prompt on the note edit screen

## Summary
This PR lets users **view, edit, save, reset, and use a custom grading prompt** for each encounter directly from the note edit screen. The saved prompt is stored in the existing **in-memory `Encounter`** record (no external DB). The `/api/review` endpoint now consumes the **inline override → saved override → default** prompt, in that priority.

---

## What’s included

### 1) Extract default prompt to a shared module
- **New** `src/lib/reviewPrompt.ts` exporting `defaultReviewPrompt: string`.
- **Changed** `src/app/api/review/route.ts` to import and use it as the fallback (no behavior change for defaults).

### 2) Extend the Encounter model (no DB required)
- **Changed** `src/lib/store.ts` `Encounter`:
  - `reviewPrompt?: string`
  - `reviewPromptEditedAt?: Date`
- Stored in the existing global in-memory `Map` (same store used across the app).

### 3) New API: `/api/review-prompt` (GET, PUT, DELETE)
- **New** `src/app/api/review-prompt/route.ts`
  - `GET ?id=<encId>` → `{ id, prompt: string | null, defaultPrompt: string }`
  - `PUT { id, prompt }` → trims; max **12,000** chars; saves to `Encounter`
  - `DELETE { id }` → clears saved override
- Errors: `404` if encounter missing; `400` for bad input; `413` if over size limit.

### 4) Update `/api/review` to use the effective prompt
- **Changed** `src/app/api/review/route.ts`:
  - Accept optional `gradingPrompt` in the request body.
  - Resolve prompt in this order:
    1. `gradingPrompt` (inline for one-off runs)
    2. `Encounter.reviewPrompt` (saved per encounter)
    3. `defaultReviewPrompt` (shared module)
- Response schema unchanged; only the system message content varies.
- Existing caller still works: note page posts `{ id, studentNote }` to `/api/review`.

### 5) UI: “Edit grading prompt” on the note page
- **Changed** `src/app/note/[id]/page.tsx`:
  - Adds a secondary button **Edit grading prompt** near the submit area.
  - Opens a panel/modal with:
    - A large textarea prefilled with the **effective prompt** (saved or default)
    - Live character count + soft token estimate
    - **Save**, **Reset to default**, **Cancel**
  - `Save` → `PUT /api/review-prompt`
  - `Reset` → `DELETE /api/review-prompt`, then show default
  - Submit flow untouched: still posts `{ id, studentNote }` to `/api/review`.

---

## API Shapes

### `GET /api/review-prompt?id=<encId>`
```json
{ "id": "string", "prompt": "string|null", "defaultPrompt": "string" }
```

### `PUT /api/review-prompt`
```json
{ "id": "string", "prompt": "string (<= 12000 chars)" }
```

### `DELETE /api/review-prompt`
```json
{ "id": "string" }
```

### `/api/review` (existing, now with optional override)
```json
{ "id": "string", "studentNote": "string", "gradingPrompt": "string (optional)" }
```

---

## UX details
- Edit flow mirrors: **Edit → Save → Submit for Review**.
- Helper text: “This prompt guides **grading** only (does not change your SOAP text).”
- Safety rails:
  - Length limit: **12,000** chars; disable Save + show error if exceeded.
  - “Reset to default” confirmation.

---

## Testing / QA

1. **Baseline**  
   - With no override saved, submit a review → behavior identical to main.

2. **Save override**  
   - On `/note/[id]`, open **Edit grading prompt**, modify a line, **Save**.  
   - Refresh: editor shows saved text from `/api/review-prompt?id=…`.  
   - Submit Review: verify results differ if you changed rubric emphasis.

3. **Inline override (no persistence)**  
   - Manually POST to `/api/review` with `gradingPrompt` set; the saved prompt should remain unchanged.

4. **Reset**  
   - Click **Reset to default**; refresh page; editor shows default again.

5. **Error cases**  
   - Try saving >12k chars → Save disabled (client), API returns `413` if forced.  
   - Bad/missing `id` → `404`.

---

## Performance / Security
- No additional network calls during submit unless the prompt is edited.
- Prompt text is user-generated; trimmed and size-bounded before storing/using.
- Data remains **ephemeral and per-process** (same behavior as existing store).

---

## Migration / Backward compatibility
- Fully backward compatible:
  - If you never touch the new UI, `/api/review` still uses the default prompt.
  - Existing consumers of `/api/review` need no changes (new body field is optional).

---

## Future work (out of scope)
- Persist prompts across restarts (e.g., localStorage sync or query-string encoding).
- Per-course / per-user prompt presets.
- Versioning/audit trail for prompts.
